### PR TITLE
hsc velocity tutorial: document transition_genes selection

### DIFF
--- a/301_tutorial_hsc_velocity.ipynb
+++ b/301_tutorial_hsc_velocity.ipynb
@@ -539,6 +539,25 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Selecting genes for the velocity projection\n",
+    "\n",
+    "`dyn.tl.cell_velocities` projects the high-dimensional RNA velocities onto the low-dimensional embedding using a set of **transition genes** (stored in `adata.var['use_for_transition']`). By default these are chosen automatically, but you can restrict them with the `transition_genes` argument — either a **list of gene names** or a **boolean mask** over `adata.var_names`:\n",
+    "\n",
+    "```python\n",
+    "# only project a curated gene set\n",
+    "dyn.tl.cell_velocities(adata, transition_genes=['Gata1', 'Spi1', 'Elane'])\n",
+    "\n",
+    "# or a boolean mask (e.g. your own selection column)\n",
+    "dyn.tl.cell_velocities(adata, transition_genes=adata.var['my_selected_genes'].values)\n",
+    "```\n",
+    "\n",
+    "Genes whose velocity is non-finite are dropped from the set automatically. This is useful when you want the streamlines to reflect a specific pathway or lineage program rather than all dynamics genes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8f770fb0-a108-42f3-901b-7761b6b967ad",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Adds a short note to `301_tutorial_hsc_velocity.ipynb` on restricting the RNA-velocity projection to a chosen gene set via `dyn.tl.cell_velocities(..., transition_genes=...)` — accepts a list of gene names or a boolean mask.

The boolean-mask form is fixed in aristoteleo/dynamo-release#759 (previously raised an `IndexError`).

Markdown-only; no re-execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD7gAdxa3Zt5uiQVDoANa5